### PR TITLE
Update Ethereum tests to release 9.0.2

### DIFF
--- a/ethjson/src/spec/spec.rs
+++ b/ethjson/src/spec/spec.rs
@@ -40,8 +40,10 @@ pub enum ForkSpec {
 	ConstantinopleFix,
 	/// Istanbul (#9,069,000, 2019-12-08)
 	Istanbul,
-	/// Berlin (To be announced)
+	/// Berlin (#12,244,000, 2021-04-15)
 	Berlin,
+	/// London (To be announced)
+	London,
 	/// Byzantium transition test-net
 	EIP158ToByzantiumAt5,
 	/// Homestead transition test-net

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -93,3 +93,14 @@ pub fn run(dir: &str) {
 #[test] fn st_zero_calls() { run("res/ethtests/GeneralStateTests/stZeroCallsTest") }
 #[test] fn st_zero_knowledge() { run("res/ethtests/GeneralStateTests/stZeroKnowledge") }
 #[test] fn st_zero_knowledge2() { run("res/ethtests/GeneralStateTests/stZeroKnowledge2") }
+
+mod vm {
+	use super::*;
+
+	#[test] fn vm_arithmetic() { run("res/ethtests/GeneralStateTests/VMTests/vmArithmeticTest"); }
+	#[test] fn vm_bitwise_logic() { run("res/ethtests/GeneralStateTests/VMTests/vmBitwiseLogicOperation"); }
+	#[test] fn vm_io_and_flow() { run("res/ethtests/GeneralStateTests/VMTests/vmIOandFlowOperations"); }
+	#[test] fn vm_log() { run("res/ethtests/GeneralStateTests/VMTests/vmLogTest"); }
+	#[test] #[ignore] fn vm_performance() { run("res/ethtests/GeneralStateTests/VMTests/vmPerformance"); }
+	#[test] fn vm_other() { run("res/ethtests/GeneralStateTests/VMTests/vmTests"); }
+}

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -41,7 +41,6 @@ pub fn run(dir: &str) {
 #[test] fn st_call_delegate_codes_call_code_homestead() { run("res/ethtests/GeneralStateTests/stCallDelegateCodesCallCodeHomestead") }
 #[test] fn st_call_delegate_codes_homestead() { run("res/ethtests/GeneralStateTests/stCallDelegateCodesHomestead") }
 #[test] fn st_chain_id() { run("res/ethtests/GeneralStateTests/stChainId") }
-#[test] fn st_changed_eip150() { run("res/ethtests/GeneralStateTests/stChangedEIP150") }
 #[test] fn st_code_copy() { run("res/ethtests/GeneralStateTests/stCodeCopyTest") }
 #[test] fn st_code_size_limit() { run("res/ethtests/GeneralStateTests/stCodeSizeLimit") }
 #[test] #[ignore] fn st_create2() { run("res/ethtests/GeneralStateTests/stCreate2") }
@@ -50,7 +49,8 @@ pub fn run(dir: &str) {
 #[test] fn st_eip150_single_code_gas_prices() { run("res/ethtests/GeneralStateTests/stEIP150singleCodeGasPrices") }
 #[test] fn st_eip150_specific() { run("res/ethtests/GeneralStateTests/stEIP150Specific") }
 #[test] fn st_eip158_specific() { run("res/ethtests/GeneralStateTests/stEIP158Specific") }
-#[test] fn st_example() { run("res/ethtests/GeneralStateTests/stExample") }
+// post-Berlin transaction descriptions without gasPrice
+#[test] #[ignore] fn st_example() { run("res/ethtests/GeneralStateTests/stExample") }
 #[test] fn st_ext_code_hash() { run("res/ethtests/GeneralStateTests/stExtCodeHash") }
 #[test] fn st_homestead_specific() { run("res/ethtests/GeneralStateTests/stHomesteadSpecific") }
 #[test] fn st_init_code() { run("res/ethtests/GeneralStateTests/stInitCodeTest") }

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -50,6 +50,10 @@ pub fn run(dir: &str) {
 #[test] fn st_eip150_specific() { run("res/ethtests/GeneralStateTests/stEIP150Specific") }
 #[test] fn st_eip158_specific() { run("res/ethtests/GeneralStateTests/stEIP158Specific") }
 // post-Berlin transaction descriptions without gasPrice
+#[test] #[ignore] fn st_eip1559() { run("res/ethtests/GeneralStateTests/stEIP1559") }
+// post-Berlin transaction descriptions without gasPrice
+#[test] #[ignore] fn st_eip2930() { run("res/ethtests/GeneralStateTests/stEIP2930") }
+// post-Berlin transaction descriptions without gasPrice
 #[test] #[ignore] fn st_example() { run("res/ethtests/GeneralStateTests/stExample") }
 #[test] fn st_ext_code_hash() { run("res/ethtests/GeneralStateTests/stExtCodeHash") }
 #[test] fn st_homestead_specific() { run("res/ethtests/GeneralStateTests/stHomesteadSpecific") }
@@ -79,7 +83,9 @@ pub fn run(dir: &str) {
 #[test] #[ignore] fn st_sstore() { run("res/ethtests/GeneralStateTests/stSStoreTest") }
 #[test] fn st_stack() { run("res/ethtests/GeneralStateTests/stStackTests") }
 #[test] #[ignore] fn st_static_call() { run("res/ethtests/GeneralStateTests/stStaticCall") }
+#[test] fn st_static_flag_enabled() { run("res/ethtests/GeneralStateTests/stStaticFlagEnabled") }
 #[test] fn st_system_operations() { run("res/ethtests/GeneralStateTests/stSystemOperationsTest") }
+#[test] #[ignore] fn st_time_consuming() { run("res/ethtests/GeneralStateTests/stTimeConsuming") }
 #[test] fn st_transaction() { run("res/ethtests/GeneralStateTests/stTransactionTest") }
 #[test] fn st_transition() { run("res/ethtests/GeneralStateTests/stTransitionTest") }
 #[test] fn st_wallet() { run("res/ethtests/GeneralStateTests/stWalletTest") }

--- a/jsontests/tests/vm.rs
+++ b/jsontests/tests/vm.rs
@@ -26,15 +26,15 @@ pub fn run(dir: &str) {
 	}
 }
 
-#[test] fn vm_arithmetic() { run("res/ethtests/VMTests/vmArithmeticTest"); }
-#[test] fn vm_bitwise_logic() { run("res/ethtests/VMTests/vmBitwiseLogicOperation"); }
-#[test] fn vm_block_info() { run("res/ethtests/VMTests/vmBlockInfoTest"); }
-#[test] fn vm_environmental_info() { run("res/ethtests/VMTests/vmEnvironmentalInfo"); }
-#[test] fn vm_io_and_flow() { run("res/ethtests/VMTests/vmIOandFlowOperations"); }
-#[test] fn vm_log() { run("res/ethtests/VMTests/vmLogTest"); }
-#[test] #[ignore] fn vm_performance() { run("res/ethtests/VMTests/vmPerformance"); }
-#[test] fn vm_push_dup_swap() { run("res/ethtests/VMTests/vmPushDupSwapTest"); }
-#[test] fn vm_random() { run("res/ethtests/VMTests/vmRandomTest"); }
-#[test] fn vm_sha3() { run("res/ethtests/VMTests/vmSha3Test"); }
-#[test] fn vm_system() { run("res/ethtests/VMTests/vmSystemOperations"); }
-#[test] fn vm_other() { run("res/ethtests/VMTests/vmTests"); }
+#[test] fn vm_arithmetic() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmArithmeticTest"); }
+#[test] fn vm_bitwise_logic() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation"); }
+#[test] fn vm_block_info() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmBlockInfoTest"); }
+#[test] fn vm_environmental_info() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo"); }
+#[test] fn vm_io_and_flow() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations"); }
+#[test] fn vm_log() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmLogTest"); }
+#[test] #[ignore] fn vm_performance() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmPerformance"); }
+#[test] fn vm_push_dup_swap() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest"); }
+#[test] fn vm_random() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmRandomTest"); }
+#[test] fn vm_sha3() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmSha3Test"); }
+#[test] fn vm_system() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmSystemOperations"); }
+#[test] fn vm_other() { run("res/ethtests/LegacyTests/Constantinople/VMTests/vmTests"); }


### PR DESCRIPTION
Update test coverage to the currently maintained state test cases.
The old Constantinople-era VM tests live on in the `LegacyTests` directory, so these are still run as well.

The state test description loader is compatible with most of the current test cases, except a few that use the new (and undocumented) transaction description format that SputnikVM does not have the means to support yet.