### PR TITLE
Bump eth tests

### DIFF
--- a/ethjson/src/spec/spec.rs
+++ b/ethjson/src/spec/spec.rs
@@ -44,6 +44,8 @@ pub enum ForkSpec {
 	Berlin,
 	/// London (To be announced)
 	London,
+	/// Merge/Paris (To be announced)
+	Merge,
 	/// Byzantium transition test-net
 	EIP158ToByzantiumAt5,
 	/// Homestead transition test-net


### PR DESCRIPTION
Few of the tests are failing, related to the example or overflow:

st_transaction->HighGasPrice:Istanbul:0
st_example->accessListExample:Istanbul:0
st_create->CreateTransactionHighNonce:London:0