### PR TITLE
chore: sync with upstream for Shanghai changes

### DIFF
--- a/ethjson/src/spec/spec.rs
+++ b/ethjson/src/spec/spec.rs
@@ -42,8 +42,13 @@ pub enum ForkSpec {
 	Istanbul,
 	/// Berlin (#12,244,000, 2021-04-15)
 	Berlin,
-	/// London (To be announced)
+	/// London (#12,965,000, 2021-08-05)
 	London,
+	/// Paris - The Merge (#15,537,394, 2022-09-15)
+	Merge,
+	/// Shanghai (#17,034,870, 2023-04-12)
+	Shanghai,
+
 	/// Byzantium transition test-net
 	EIP158ToByzantiumAt5,
 	/// Homestead transition test-net
@@ -56,6 +61,17 @@ pub enum ForkSpec {
 	ByzantiumToConstantinopleFixAt5,
 	/// Istanbul transition test-net
 	ConstantinopleFixToIstanbulAt5,
+}
+
+impl ForkSpec {
+	/// Returns true if the fork is at or after the merge.
+	pub fn is_eth2(&self) -> bool {
+		// NOTE: Include new forks in this match arm.
+		matches!(
+			*self,
+			ForkSpec::London | ForkSpec::Merge | ForkSpec::Shanghai
+		)
+	}
 }
 
 /// Spec deserialization.

--- a/ethjson/src/vm.rs
+++ b/ethjson/src/vm.rs
@@ -121,6 +121,10 @@ pub struct Env {
 	#[serde(rename = "currentBaseFee")]
 	#[serde(default)]
 	pub block_base_fee_per_gas: Uint,
+	/// Pre-seeded random value for testing
+	#[serde(rename = "currentRandom")]
+	#[serde(default)]
+	pub random: Option<Uint>,
 }
 
 #[cfg(test)]
@@ -145,7 +149,8 @@ mod tests {
 				"currentDifficulty" : "0x0100",
 				"currentGasLimit" : "0x0f4240",
 				"currentNumber" : "0x00",
-				"currentTimestamp" : "0x01"
+				"currentTimestamp" : "0x01",
+				"currentRandom" : "0x01"
 			},
 			"exec" : {
 				"address" : "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
@@ -192,7 +197,8 @@ mod tests {
 				gas_limit: Uint(0x0f4240.into()),
 				number: Uint(0.into()),
 				timestamp: Uint(1.into()),
-				block_base_fee_per_gas: Uint(0.into())
+				block_base_fee_per_gas: Uint(0.into()),
+				random: Some(Uint(1.into())),
 			}
 		);
 		assert_eq!(

--- a/jsontests/src/utils.rs
+++ b/jsontests/src/utils.rs
@@ -144,9 +144,9 @@ pub fn assert_valid_hash(h: &H256, b: &BTreeMap<H160, MemoryAccount>) {
 		.collect::<Vec<_>>();
 
 	let root = ethereum::util::sec_trie_root(tree);
-	let expect = h.clone().into();
+	let expect = h;
 
-	if root != expect {
+	if root != *expect {
 		panic!(
 			"Hash not equal; calculated: {:?}, expect: {:?}\nState: {:#x?}",
 			root, expect, b
@@ -157,7 +157,7 @@ pub fn assert_valid_hash(h: &H256, b: &BTreeMap<H160, MemoryAccount>) {
 pub fn flush() {
 	use std::io::{self, Write};
 
-	io::stdout().flush().ok().expect("Could not flush stdout");
+	io::stdout().flush().expect("Could not flush stdout");
 }
 
 pub mod transaction {

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -13,7 +13,7 @@ pub fn run(dir: &str) {
 	for entry in fs::read_dir(dest).unwrap() {
 		let entry = entry.unwrap();
 		if let Some(s) = entry.file_name().to_str() {
-			if s.starts_with(".") {
+			if s.starts_with('.') {
 				continue;
 			}
 		}
@@ -23,8 +23,8 @@ pub fn run(dir: &str) {
 		let file = File::open(path).expect("Open file failed");
 
 		let reader = BufReader::new(file);
-		let coll = serde_json::from_reader::<_, HashMap<String, statetests::Test>>(reader)
-			.expect("Parse test cases failed");
+		let coll: HashMap<String, statetests::Test> =
+			serde_json::from_reader(reader).expect("Parse test cases failed");
 
 		for (name, test) in coll {
 			statetests::test(&name, test);


### PR DESCRIPTION
This PR updates the `jsontests/res/ethtests` submodule to include tests for the recent Shanghai hard fork.

The repo hasn't been updated since before the Merge, so specifics around that have been added here as well.