### PR TITLE
fix: skip test cases failing in geth

### DIFF
--- a/jsontests/src/state.rs
+++ b/jsontests/src/state.rs
@@ -261,19 +261,18 @@ fn test_run(name: &str, test: Test) {
 			// Test case may be expected to fail with an unsupported tx type if the current fork is
 			// older than Berlin (see EIP-2718). However, this is not implemented in sputnik itself and rather
 			// in the code hosting sputnik. https://github.com/rust-blockchain/evm/pull/40
-			let tx_type = TxType::from_txbytes(&state.txbytes);
-			if matches!(
-				spec,
-				ForkSpec::EIP150
-					| ForkSpec::EIP158 | ForkSpec::Frontier
-					| ForkSpec::Homestead
-					| ForkSpec::Byzantium
-					| ForkSpec::Constantinople
-					| ForkSpec::ConstantinopleFix
-					| ForkSpec::Istanbul
-			) && tx_type != TxType::Legacy
-				&& state.expect_exception == Some("TR_TypeNotSupported".to_string())
-			{
+			let expect_tx_type_not_supported =
+				matches!(
+					spec,
+					ForkSpec::EIP150
+						| ForkSpec::EIP158 | ForkSpec::Frontier
+						| ForkSpec::Homestead | ForkSpec::Byzantium
+						| ForkSpec::Constantinople
+						| ForkSpec::ConstantinopleFix
+						| ForkSpec::Istanbul
+				) && TxType::from_txbytes(&state.txbytes) != TxType::Legacy
+					&& state.expect_exception.as_deref() == Some("TR_TypeNotSupported");
+			if expect_tx_type_not_supported {
 				continue;
 			}
 


### PR DESCRIPTION
This patch adds filtering logic to `jsontests/tests/state.rs` to skip individual test cases (rather than entire test directories), which is used to skip cases that are failing both in geth and here. These can't currently be fixed until we have a correct reference implementation. These cases are:

* stTransactionTest/HighGasPrice
* stCreateTest/CreateTransactionHighNonce

Further, another test case is skipped due to different implementation details of the test suite (see code comments):
* stTransactionTest/ValueOverflow

---

This PR along with https://github.com/rust-blockchain/evm/pull/162 and https://github.com/rust-blockchain/evm/pull/163 brings sputnikvm and the testsuite to parity with geth.