### PR TITLE
chore: update some dependencies and add CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,61 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run clippy simple
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D clippy::all -D clippy::nursery
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run tests simple
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-targets
+
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --all-targets

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "evm"]
 	path = evm
-	url = https://github.com/rust-blockchain/evm
+	url = https://github.com/aurora-is-near/sputnikvm
 [submodule "jsontests/res/ethtests"]
 	path = jsontests/res/ethtests
 	url = https://github.com/ethereum/tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "jsontests/res/ethtests"]
 	path = jsontests/res/ethtests
 	url = https://github.com/ethereum/tests
-	tag = 9.0.5
+	tag = v12.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "environmental",
  "evm-core",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,40 +4,41 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -51,32 +52,38 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -95,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -105,32 +112,20 @@ dependencies = [
 [[package]]
 name = "bn"
 version = "0.4.4"
-source = "git+https://github.com/paritytech/bn#6079255e65793038b9a6e5292203eab482737cc2"
+source = "git+https://github.com/paritytech/bn?rev=b048fe1#b048fe1d84f1265e061dd4a6e4c44e2fd0e088b4"
 dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.5.6",
+ "rand",
  "rustc-hex",
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-slice-cast"
@@ -140,9 +135,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -152,18 +147,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
@@ -173,13 +159,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -187,40 +173,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "const_fn"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
-
-[[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
 name = "criterion"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
@@ -244,59 +209,45 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
  "itertools",
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
+ "autocfg",
+ "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "const_fn",
- "lazy_static",
+ "cfg-if",
 ]
 
 [[package]]
@@ -307,9 +258,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -327,11 +278,10 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
 dependencies = [
- "bstr",
  "csv-core",
  "itoa",
  "ryu",
@@ -340,22 +290,22 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -369,11 +319,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -388,18 +338,18 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -407,9 +357,25 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "eth_pairings"
@@ -434,7 +400,7 @@ dependencies = [
  "byteorder",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -470,7 +436,7 @@ dependencies = [
  "num",
  "parity-bytes",
  "ripemd",
- "sha2 0.10.2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -511,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -538,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.40.0"
+version = "0.39.1"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -557,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.40.0"
+version = "0.39.0"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -567,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.40.0"
+version = "0.39.0"
 dependencies = [
  "environmental",
  "evm-core",
@@ -598,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.40.0"
+version = "0.39.0"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -614,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.3",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -636,12 +602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,9 +609,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -659,20 +619,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "half"
-version = "1.6.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hash-db"
@@ -696,29 +656,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.0"
+name = "hashbrown"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
-dependencies = [
- "hex-literal-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "hex-literal-impl"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853f769599eb31de176303197b7ba4973299c38c7a7604a6bc88c3eef05b9b46"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -743,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "impl-codec"
@@ -782,38 +750,62 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "keccak-hash"
@@ -830,18 +822,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libsecp256k1"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
  "base64",
@@ -850,9 +845,9 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.3",
+ "rand",
  "serde",
- "sha2 0.9.3",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -886,13 +881,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.8"
+name = "linux-raw-sys"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-dependencies = [
- "cfg-if 0.1.10",
-]
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "maplit"
@@ -902,15 +900,15 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -952,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -962,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -985,33 +983,24 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.2"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -1021,15 +1010,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parity-bytes"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
+checksum = "16b56e3a2420138bdb970f84dfb9c774aea80fa0e7371549eedec0d80c209c67"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.1"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -1041,39 +1030,55 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "plotters"
-version = "0.2.15"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
- "js-sys",
  "num-traits",
+ "plotters-backend",
+ "plotters-svg",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
+name = "plotters-backend"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -1085,12 +1090,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror",
- "toml",
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1102,7 +1107,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1118,30 +1123,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1154,121 +1148,90 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.5.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.1",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.1",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
- "num_cpus",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-automata",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
- "byteorder",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.12"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ripemd"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1facec54cb5e0dc08553501fa740091086d0259ad0067e0d4103448e4cb22ed3"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1290,7 +1253,7 @@ checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1300,19 +1263,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
+name = "rustix"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
- "semver",
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -1325,12 +1292,12 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
@@ -1338,51 +1305,36 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcd47b380d8c4541044e341dcd9475f55ba37ddc50c908d945fc036a8642496"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -1390,20 +1342,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.41"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1412,35 +1364,35 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpuid-bool",
+ "cfg-if",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.1"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1456,6 +1408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,15 +1427,26 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1492,9 +1461,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
@@ -1509,35 +1478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,21 +1488,29 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.7"
+name = "toml_datetime"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "serde",
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1586,15 +1534,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
-version = "0.9.0"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -1604,75 +1552,74 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1680,28 +1627,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1709,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1725,9 +1672,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -1739,10 +1686,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wyz"
-version = "0.5.0"
+name = "windows-sys"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]

--- a/EIP-152/benches/bench.rs
+++ b/EIP-152/benches/bench.rs
@@ -16,134 +16,136 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use eip_152::portable;
-use std::mem;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use eip_152::avx2;
+mod avx {
+	use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+	use std::mem;
+	use std::sync::atomic::{AtomicPtr, Ordering};
 
-type FnRaw = *mut ();
-type Blake2bF = fn(&mut [u64; 8], [u64; 16], [u64; 2], bool, usize);
+	use eip_152::{avx2, portable};
 
-static FN: AtomicPtr<()> = AtomicPtr::new(detect as FnRaw);
+	type FnRaw = *mut ();
+	type Blake2bF = fn(&mut [u64; 8], [u64; 16], [u64; 2], bool, usize);
 
-fn detect(state: &mut [u64; 8], message: [u64; 16], count: [u64; 2], f: bool, rounds: usize) {
-	let fun = if is_x86_feature_detected!("avx2") {
-		avx2::compress as FnRaw
-	} else {
-		portable::compress as FnRaw
-	};
-	FN.store(fun as FnRaw, Ordering::Relaxed);
-	unsafe { mem::transmute::<FnRaw, Blake2bF>(fun)(state, message, count, f, rounds) }
-}
+	static FN: AtomicPtr<()> = AtomicPtr::new(detect as FnRaw);
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub fn avx_ifunc_benchmark(c: &mut Criterion) {
-	let mut group = c.benchmark_group("avx2_ifunc");
-
-	for rounds in [12, 50, 100].iter() {
-		group.throughput(Throughput::Elements(*rounds as u64));
-		group.bench_with_input(BenchmarkId::new("rounds", rounds), &rounds, |b, rounds| {
-			let mut state = [
-				0x6a09e667f2bdc948_u64,
-				0xbb67ae8584caa73b_u64,
-				0x3c6ef372fe94f82b_u64,
-				0xa54ff53a5f1d36f1_u64,
-				0x510e527fade682d1_u64,
-				0x9b05688c2b3e6c1f_u64,
-				0x1f83d9abfb41bd6b_u64,
-				0x5be0cd19137e2179_u64,
-			];
-
-			let message = [
-				0x0000000000636261_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-			];
-			let count = [3, 0];
-			let f = true;
-
-			b.iter(|| unsafe {
-				let fun = FN.load(Ordering::Relaxed);
-				mem::transmute::<FnRaw, Blake2bF>(fun)(
-					black_box(&mut state),
-					black_box(message),
-					black_box(count),
-					black_box(f),
-					black_box(**rounds as usize),
-				);
-			});
-		});
+	fn detect(state: &mut [u64; 8], message: [u64; 16], count: [u64; 2], f: bool, rounds: usize) {
+		let fun = if is_x86_feature_detected!("avx2") {
+			avx2::compress as FnRaw
+		} else {
+			portable::compress as FnRaw
+		};
+		FN.store(fun as FnRaw, Ordering::Relaxed);
+		unsafe { mem::transmute::<FnRaw, Blake2bF>(fun)(state, message, count, f, rounds) }
 	}
 
-	group.finish();
-}
+	pub fn avx_ifunc_benchmark(c: &mut Criterion) {
+		let mut group = c.benchmark_group("avx2_ifunc");
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub fn avx_benchmark(c: &mut Criterion) {
-	let mut group = c.benchmark_group("avx2");
+		for rounds in [12, 50, 100].iter() {
+			group.throughput(Throughput::Elements(*rounds as u64));
+			group.bench_with_input(BenchmarkId::new("rounds", rounds), &rounds, |b, rounds| {
+				let mut state = [
+					0x6a09e667f2bdc948_u64,
+					0xbb67ae8584caa73b_u64,
+					0x3c6ef372fe94f82b_u64,
+					0xa54ff53a5f1d36f1_u64,
+					0x510e527fade682d1_u64,
+					0x9b05688c2b3e6c1f_u64,
+					0x1f83d9abfb41bd6b_u64,
+					0x5be0cd19137e2179_u64,
+				];
 
-	for rounds in [12, 50, 100].iter() {
-		group.throughput(Throughput::Elements(*rounds as u64));
-		group.bench_with_input(BenchmarkId::new("rounds", rounds), &rounds, |b, rounds| {
-			let mut state = [
-				0x6a09e667f2bdc948_u64,
-				0xbb67ae8584caa73b_u64,
-				0x3c6ef372fe94f82b_u64,
-				0xa54ff53a5f1d36f1_u64,
-				0x510e527fade682d1_u64,
-				0x9b05688c2b3e6c1f_u64,
-				0x1f83d9abfb41bd6b_u64,
-				0x5be0cd19137e2179_u64,
-			];
+				let message = [
+					0x0000000000636261_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+				];
+				let count = [3, 0];
+				let f = true;
 
-			let message = [
-				0x0000000000636261_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-				0x0000000000000000_u64,
-			];
-			let count = [3, 0];
-			let f = true;
-
-			b.iter(|| unsafe {
-				avx2::compress(
-					black_box(&mut state),
-					black_box(message),
-					black_box(count),
-					black_box(f),
-					black_box(**rounds as usize),
-				);
+				b.iter(|| unsafe {
+					let fun = FN.load(Ordering::Relaxed);
+					mem::transmute::<FnRaw, Blake2bF>(fun)(
+						black_box(&mut state),
+						black_box(message),
+						black_box(count),
+						black_box(f),
+						black_box(**rounds as usize),
+					);
+				});
 			});
-		});
+		}
+
+		group.finish();
 	}
 
-	group.finish();
+	pub fn avx_benchmark(c: &mut Criterion) {
+		let mut group = c.benchmark_group("avx2");
+
+		for rounds in [12, 50, 100].iter() {
+			group.throughput(Throughput::Elements(*rounds as u64));
+			group.bench_with_input(BenchmarkId::new("rounds", rounds), &rounds, |b, rounds| {
+				let mut state = [
+					0x6a09e667f2bdc948_u64,
+					0xbb67ae8584caa73b_u64,
+					0x3c6ef372fe94f82b_u64,
+					0xa54ff53a5f1d36f1_u64,
+					0x510e527fade682d1_u64,
+					0x9b05688c2b3e6c1f_u64,
+					0x1f83d9abfb41bd6b_u64,
+					0x5be0cd19137e2179_u64,
+				];
+
+				let message = [
+					0x0000000000636261_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+					0x0000000000000000_u64,
+				];
+				let count = [3, 0];
+				let f = true;
+
+				b.iter(|| unsafe {
+					avx2::compress(
+						black_box(&mut state),
+						black_box(message),
+						black_box(count),
+						black_box(f),
+						black_box(**rounds as usize),
+					);
+				});
+			});
+		}
+
+		group.finish();
+	}
 }
 
 pub fn portable_benchmark(c: &mut Criterion) {
@@ -199,10 +201,14 @@ pub fn portable_benchmark(c: &mut Criterion) {
 	group.finish();
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 criterion_group!(
 	benches,
-	avx_benchmark,
-	avx_ifunc_benchmark,
+	avx::avx_benchmark,
+	avx::avx_ifunc_benchmark,
 	portable_benchmark
 );
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+criterion_group!(benches, portable_benchmark);
+
 criterion_main!(benches);

--- a/EIP-152/src/avx2.rs
+++ b/EIP-152/src/avx2.rs
@@ -74,7 +74,7 @@ macro_rules! _MM_SHUFFLE {
 /// let d = v[12..16];
 /// let mut b0 = [m[0], m[2], m[4], m[6]];
 ///
-///  g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+///  g1(&mut a, &mut b, &mut c, &mut d, &b0);
 /// // ... then construct b0 for `g2` etc.
 /// ```
 ///
@@ -138,40 +138,40 @@ pub unsafe fn compress(
 				t0 = _mm256_unpacklo_epi64(m0, m1); // ([0, 1, 0, 1], [2, 3, 2, 3]) = [0, 2, 0, 2]
 				t1 = _mm256_unpacklo_epi64(m2, m3); // ([4, 5, 4, 5], [6, 7, 6, 7]) = [4, 6, 4, 6]
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0); // ([0, 2, 0, 2], [4, 6, 4, 6]) = [0, 2, 4, 6]
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m0, m1); // ([0, 1, 0, 1], [2, 3, 2, 3]) = [1, 3, 1, 3]
 				t1 = _mm256_unpackhi_epi64(m2, m3); // ([4, 5, 4, 5], [6, 7, 6, 7]) = [5, 7, 5, 7]
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0); // ([1, 3, 1, 3], [5, 7, 5, 7]) = [1, 3, 5, 7]
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_unpacklo_epi64(m7, m4); // ([14, 15, 14, 15], [8, 9, 8, 9]) = [14, 8, 14, 8]
 				t1 = _mm256_unpacklo_epi64(m5, m6); // ([10, 11, 10, 11], [12, 13, 12, 13]) = [10, 12, 10, 12]
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0); // ([14, 8, 14, 8], [10, 12, 10, 12]) = [14, 8, 10, 12]
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m7, m4); // ([14, 15, 14, 15], [8, 9, 8, 9]) = [15, 9, 15, 9]
 				t1 = _mm256_unpackhi_epi64(m5, m6); // ([10, 11, 10, 11], [12, 13, 12, 13]) = [11, 13, 11, 13]
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0); // ([15, 9, 15, 9], [11, 13, 11, 13]) = [15, 9, 11, 13]
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			1 => {
 				t0 = _mm256_unpacklo_epi64(m7, m2);
 				t1 = _mm256_unpackhi_epi64(m4, m6);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m5, m4);
 				t1 = _mm256_alignr_epi8(m3, m7, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_unpackhi_epi64(m2, m0);
 				t1 = _mm256_blend_epi32(m5, m0, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_alignr_epi8(m6, m1, 8);
 				t1 = _mm256_blend_epi32(m3, m1, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			2 => {
@@ -179,20 +179,20 @@ pub unsafe fn compress(
 				t0 = _mm256_alignr_epi8(m6, m5, 8);
 				t1 = _mm256_unpackhi_epi64(m2, m7);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m4, m0);
 				t1 = _mm256_blend_epi32(m6, m1, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_alignr_epi8(m5, m4, 8);
 				t1 = _mm256_unpackhi_epi64(m1, m3);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m2, m7);
 				t1 = _mm256_blend_epi32(m0, m3, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			3 => {
@@ -200,20 +200,20 @@ pub unsafe fn compress(
 				t0 = _mm256_unpackhi_epi64(m3, m1);
 				t1 = _mm256_unpackhi_epi64(m6, m5);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m4, m0);
 				t1 = _mm256_unpacklo_epi64(m6, m7);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_alignr_epi8(m1, m7, 8);
 				t1 = _mm256_shuffle_epi32(m2, _MM_SHUFFLE!(1, 0, 3, 2));
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m4, m3);
 				t1 = _mm256_unpacklo_epi64(m5, m0);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			4 => {
@@ -221,20 +221,20 @@ pub unsafe fn compress(
 				t0 = _mm256_unpackhi_epi64(m4, m2);
 				t1 = _mm256_unpacklo_epi64(m1, m5);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_blend_epi32(m3, m0, 0x33);
 				t1 = _mm256_blend_epi32(m7, m2, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_alignr_epi8(m7, m1, 8);
 				t1 = _mm256_alignr_epi8(m3, m5, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m6, m0);
 				t1 = _mm256_unpacklo_epi64(m6, m4);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			5 => {
@@ -242,20 +242,20 @@ pub unsafe fn compress(
 				t0 = _mm256_unpacklo_epi64(m1, m3);
 				t1 = _mm256_unpacklo_epi64(m0, m4);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m6, m5);
 				t1 = _mm256_unpackhi_epi64(m5, m1);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_alignr_epi8(m2, m0, 8);
 				t1 = _mm256_unpackhi_epi64(m3, m7);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m4, m6);
 				t1 = _mm256_alignr_epi8(m7, m2, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			6 => {
@@ -263,20 +263,20 @@ pub unsafe fn compress(
 				t0 = _mm256_blend_epi32(m0, m6, 0x33);
 				t1 = _mm256_unpacklo_epi64(m7, m2);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m2, m7);
 				t1 = _mm256_alignr_epi8(m5, m6, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_unpacklo_epi64(m4, m0);
 				t1 = _mm256_blend_epi32(m4, m3, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m5, m3);
 				t1 = _mm256_shuffle_epi32(m1, _MM_SHUFFLE!(1, 0, 3, 2));
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			7 => {
@@ -284,20 +284,20 @@ pub unsafe fn compress(
 				t0 = _mm256_unpackhi_epi64(m6, m3);
 				t1 = _mm256_blend_epi32(m1, m6, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_alignr_epi8(m7, m5, 8);
 				t1 = _mm256_unpackhi_epi64(m0, m4);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_blend_epi32(m2, m1, 0x33);
 				t1 = _mm256_alignr_epi8(m4, m7, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m5, m0);
 				t1 = _mm256_unpacklo_epi64(m2, m3);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			8 => {
@@ -305,20 +305,20 @@ pub unsafe fn compress(
 				t0 = _mm256_unpacklo_epi64(m3, m7);
 				t1 = _mm256_alignr_epi8(m0, m5, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpackhi_epi64(m7, m4);
 				t1 = _mm256_alignr_epi8(m4, m1, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_unpacklo_epi64(m5, m6);
 				t1 = _mm256_unpackhi_epi64(m6, m0);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_alignr_epi8(m1, m2, 8);
 				t1 = _mm256_alignr_epi8(m2, m3, 8);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 			_ => {
@@ -326,20 +326,20 @@ pub unsafe fn compress(
 				t0 = _mm256_unpacklo_epi64(m5, m4);
 				t1 = _mm256_unpackhi_epi64(m3, m0);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_unpacklo_epi64(m1, m2);
 				t1 = _mm256_blend_epi32(m2, m3, 0x33);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				diagonalize(&mut a, &mut b, &mut c, &mut d);
 				t0 = _mm256_unpackhi_epi64(m6, m7);
 				t1 = _mm256_unpackhi_epi64(m4, m1);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g1(&mut a, &mut b, &mut c, &mut d, &b0);
 				t0 = _mm256_blend_epi32(m5, m0, 0x33);
 				t1 = _mm256_unpacklo_epi64(m7, m6);
 				b0 = _mm256_blend_epi32(t0, t1, 0xF0);
-				g2(&mut a, &mut b, &mut c, &mut d, &mut b0);
+				g2(&mut a, &mut b, &mut c, &mut d, &b0);
 				undiagonalize(&mut a, &mut b, &mut c, &mut d);
 			}
 		}
@@ -415,7 +415,7 @@ unsafe fn rotate_right_63(x: __m256i) -> __m256i {
 }
 
 #[inline(always)]
-unsafe fn g1(a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i, m: &mut __m256i) {
+unsafe fn g1(a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i, m: &__m256i) {
 	*a = add(*a, *m);
 	*a = add(*a, *b);
 	*d = xor(*d, *a);
@@ -426,7 +426,7 @@ unsafe fn g1(a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i,
 }
 
 #[inline(always)]
-unsafe fn g2(a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i, m: &mut __m256i) {
+unsafe fn g2(a: &mut __m256i, b: &mut __m256i, c: &mut __m256i, d: &mut __m256i, m: &__m256i) {
 	*a = add(*a, *m);
 	*a = add(*a, *b);
 	*d = xor(*d, *a);

--- a/EIP-152/src/avx2.rs
+++ b/EIP-152/src/avx2.rs
@@ -38,20 +38,20 @@ macro_rules! _MM_SHUFFLE {
 /// `g1` only operates on `x` from the original g function.
 ///  ```
 /// fn portable_g1(v: &mut [u64], a: usize, b: usize, c: usize, d: usize, x: u64) {
-///		v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
-///		v[d] = (v[d] ^ v[a]).rotate_right(32);
-///		v[c] = v[c].wrapping_add(v[d]);
-///		v[b] = (v[b] ^ v[c]).rotate_right(24);
+///     v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
+///     v[d] = (v[d] ^ v[a]).rotate_right(32);
+///     v[c] = v[c].wrapping_add(v[d]);
+///     v[b] = (v[b] ^ v[c]).rotate_right(24);
 /// }
 /// ```
 ///
-/// `g2` only operates on `y` from the originial g function.
+/// `g2` only operates on `y` from the original g function.
 /// ```
 /// fn portable_g2(v: &mut [u64], a: usize, b: usize, c: usize, d: usize, y: u64) {
-///		v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
-///		v[d] = (v[d] ^ v[a]).rotate_right(16);
-///		v[c] = v[c].wrapping_add(v[d]);
-///		v[b] = (v[b] ^ v[c]).rotate_right(63);
+///     v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
+///     v[d] = (v[d] ^ v[a]).rotate_right(16);
+///     v[c] = v[c].wrapping_add(v[d]);
+///     v[b] = (v[b] ^ v[c]).rotate_right(63);
 /// }
 /// ```
 ///
@@ -62,11 +62,11 @@ macro_rules! _MM_SHUFFLE {
 /// `SIGMA` for round 1 i.e `SIGMA[0]` = `[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15]`;
 /// ```
 ///  let s = &SIGMA[0 % 10];
-/// //        a, b, c, d,    x
+/// // a, b, c, d, x
 /// g(&mut v, 0, 4, 8 , 12, m[s[0]]);
-///	g(&mut v, 1, 5, 9 , 13, m[s[2]]);
-///	g(&mut v, 2, 6, 10, 14, m[s[4]]);
-///	g(&mut v, 3, 7, 11, 15, m[s[6]]);
+/// g(&mut v, 1, 5, 9 , 13, m[s[2]]);
+/// g(&mut v, 2, 6, 10, 14, m[s[4]]);
+/// g(&mut v, 3, 7, 11, 15, m[s[6]]);
 ///
 /// let a = v[..4];
 /// let b = v[4..8];
@@ -75,10 +75,11 @@ macro_rules! _MM_SHUFFLE {
 /// let mut b0 = [m[0], m[2], m[4], m[6]];
 ///
 ///  g1(&mut a, &mut b, &mut c, &mut d, &mut b0);
-/// // ... then contruct b0 for `g2` etc.
+/// // ... then construct b0 for `g2` etc.
 /// ```
 ///
 #[target_feature(enable = "avx2")]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn compress(
 	state: &mut [u64; 8],
 	message: [u64; 16],

--- a/EIP-152/src/lib.rs
+++ b/EIP-152/src/lib.rs
@@ -52,9 +52,9 @@ pub fn compress(state: &mut [u64; 8], message: [u64; 16], count: [u64; 2], f: bo
 	#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 	{
 		if is_x86_feature_detected!("avx2") {
-			unsafe { return avx2::compress(state, message, count, f, rounds) }
+			unsafe { avx2::compress(state, message, count, f, rounds) }
 		} else {
-			return portable::compress(state, message, count, f, rounds);
+			portable::compress(state, message, count, f, rounds);
 		};
 	}
 
@@ -120,20 +120,20 @@ mod tests {
 		portable::compress(&mut h_in, m, c, f, rounds);
 		assert_eq!(h_in, h_out);
 
-		let mut h_in = [
-			0x6a09e667f2bdc948_u64,
-			0xbb67ae8584caa73b_u64,
-			0x3c6ef372fe94f82b_u64,
-			0xa54ff53a5f1d36f1_u64,
-			0x510e527fade682d1_u64,
-			0x9b05688c2b3e6c1f_u64,
-			0x1f83d9abfb41bd6b_u64,
-			0x5be0cd19137e2179_u64,
-		];
-
 		// avx
 		#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 		{
+			let mut h_in = [
+				0x6a09e667f2bdc948_u64,
+				0xbb67ae8584caa73b_u64,
+				0x3c6ef372fe94f82b_u64,
+				0xa54ff53a5f1d36f1_u64,
+				0x510e527fade682d1_u64,
+				0x9b05688c2b3e6c1f_u64,
+				0x1f83d9abfb41bd6b_u64,
+				0x5be0cd19137e2179_u64,
+			];
+
 			if is_x86_feature_detected!("avx2") {
 				unsafe {
 					avx2::compress(&mut h_in, m, c, f, rounds);

--- a/EIP-152/src/lib.rs
+++ b/EIP-152/src/lib.rs
@@ -180,7 +180,6 @@ mod tests {
 //			),
 		];
 		for (hex, output) in vec {
-			let hex = hex;
 			let bytes: Vec<u8> = hex.from_hex().unwrap();
 
 			assert_eq!(bytes.len(), 213);

--- a/ethcore-builtin/Cargo.toml
+++ b/ethcore-builtin/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-bn = { git = "https://github.com/paritytech/bn", default-features = false }
+bn = { git = "https://github.com/paritytech/bn", rev = "b048fe1", default-features = false }
 byteorder = "1.3.2"
 eip-152 = { path = "../EIP-152" }
 ethereum-types = "0.14"
@@ -21,5 +21,5 @@ sha2 = { version = "0.10.0", default-features = false }
 eth_pairings = { git = "https://github.com/matter-labs/eip1962.git", default-features = false, features = ["eip_2537"], rev = "ece6cbabc41948db4200e41f0bfdab7ab94c7af8" }
 
 [dev-dependencies]
-hex-literal = "0.2.1"
+hex-literal = "0.4"
 maplit = "1.0.2"

--- a/ethjson/src/bytes.rs
+++ b/ethjson/src/bytes.rs
@@ -30,7 +30,7 @@ pub struct Bytes(Vec<u8>);
 impl Bytes {
 	/// Creates bytes struct.
 	pub fn new(v: Vec<u8>) -> Self {
-		Bytes(v)
+		Self(v)
 	}
 }
 
@@ -42,7 +42,7 @@ impl From<Bytes> for Vec<u8> {
 
 impl From<Vec<u8>> for Bytes {
 	fn from(bytes: Vec<u8>) -> Self {
-		Bytes(bytes)
+		Self(bytes)
 	}
 }
 
@@ -69,7 +69,7 @@ impl FromStr for Bytes {
 			_ => FromHex::from_hex(value).unwrap_or_default(),
 		};
 
-		Ok(Bytes(v))
+		Ok(Self(v))
 	}
 }
 

--- a/ethjson/src/maybe.rs
+++ b/ethjson/src/maybe.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Deserializer};
 use crate::uint::Uint;
 
 /// Deserializer of empty string values into optionals.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MaybeEmpty<T> {
 	/// Some.
 	Some(T),
@@ -51,8 +51,8 @@ struct MaybeEmptyVisitor<T> {
 }
 
 impl<T> MaybeEmptyVisitor<T> {
-	fn new() -> Self {
-		MaybeEmptyVisitor {
+	const fn new() -> Self {
+		Self {
 			_phantom: PhantomData,
 		}
 	}
@@ -87,9 +87,9 @@ where
 	}
 }
 
-impl<T> Into<Option<T>> for MaybeEmpty<T> {
-	fn into(self) -> Option<T> {
-		match self {
+impl<T> From<MaybeEmpty<T>> for Option<T> {
+	fn from(val: MaybeEmpty<T>) -> Self {
+		match val {
 			MaybeEmpty::Some(s) => Some(s),
 			MaybeEmpty::None => None,
 		}
@@ -99,21 +99,21 @@ impl<T> Into<Option<T>> for MaybeEmpty<T> {
 #[cfg(test)]
 impl From<Uint> for MaybeEmpty<Uint> {
 	fn from(uint: Uint) -> Self {
-		MaybeEmpty::Some(uint)
+		Self::Some(uint)
 	}
 }
 
 impl From<MaybeEmpty<Uint>> for U256 {
-	fn from(maybe: MaybeEmpty<Uint>) -> U256 {
+	fn from(maybe: MaybeEmpty<Uint>) -> Self {
 		match maybe {
 			MaybeEmpty::Some(v) => v.0,
-			MaybeEmpty::None => U256::zero(),
+			MaybeEmpty::None => Self::zero(),
 		}
 	}
 }
 
 impl From<MaybeEmpty<Uint>> for u64 {
-	fn from(maybe: MaybeEmpty<Uint>) -> u64 {
+	fn from(maybe: MaybeEmpty<Uint>) -> Self {
 		match maybe {
 			MaybeEmpty::Some(v) => v.0.low_u64(),
 			MaybeEmpty::None => 0u64,
@@ -123,7 +123,7 @@ impl From<MaybeEmpty<Uint>> for u64 {
 
 impl Default for MaybeEmpty<Uint> {
 	fn default() -> Self {
-		MaybeEmpty::Some(Uint::default())
+		Self::Some(Uint::default())
 	}
 }
 

--- a/ethjson/src/spec/account.rs
+++ b/ethjson/src/spec/account.rs
@@ -45,7 +45,7 @@ pub struct Account {
 
 impl Account {
 	/// Returns true if account does not have nonce, balance, code and storage.
-	pub fn is_empty(&self) -> bool {
+	pub const fn is_empty(&self) -> bool {
 		self.balance.is_none()
 			&& self.nonce.is_none()
 			&& self.code.is_none()

--- a/ethjson/src/spec/authority_round.rs
+++ b/ethjson/src/spec/authority_round.rs
@@ -195,7 +195,7 @@ mod tests {
 		];
 		assert_eq!(
 			deserialized.params.block_gas_limit_contract_transitions,
-			Some(expected_bglc.to_vec().into_iter().collect())
+			Some(expected_bglc.iter().copied().collect())
 		);
 	}
 }

--- a/ethjson/src/spec/builtin.rs
+++ b/ethjson/src/spec/builtin.rs
@@ -22,7 +22,7 @@ use crate::uint::Uint;
 use serde::Deserialize;
 
 /// Linear pricing.
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Linear {
 	/// Base price.
@@ -32,7 +32,7 @@ pub struct Linear {
 }
 
 /// Pricing for modular exponentiation.
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Modexp {
 	/// Price divisor.
@@ -42,7 +42,7 @@ pub struct Modexp {
 }
 
 /// Pricing for constant alt_bn128 operations (ECADD and ECMUL)
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct AltBn128ConstOperations {
 	/// price
@@ -50,7 +50,7 @@ pub struct AltBn128ConstOperations {
 }
 
 /// Pricing for alt_bn128_pairing.
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct AltBn128Pairing {
 	/// Base price.
@@ -60,7 +60,7 @@ pub struct AltBn128Pairing {
 }
 
 /// Bls12 pairing price
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Bls12Pairing {
 	/// Price per final exp
@@ -70,7 +70,7 @@ pub struct Bls12Pairing {
 }
 
 /// Pricing for constant Bls12 operations (ADD and MUL in G1 and G2, as well as mappings)
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Bls12ConstOperations {
 	/// Fixed price.
@@ -78,7 +78,7 @@ pub struct Bls12ConstOperations {
 }
 
 /// Pricing for constant Bls12 operations (ADD and MUL in G1, as well as mappings)
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Bls12G1Multiexp {
 	/// Base const of the operation (G1 or G2 multiplication)
@@ -86,7 +86,7 @@ pub struct Bls12G1Multiexp {
 }
 
 /// Pricing for constant Bls12 operations (ADD and MUL in G2, as well as mappings)
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Bls12G2Multiexp {
 	/// Base const of the operation (G1 or G2 multiplication)
@@ -94,7 +94,7 @@ pub struct Bls12G2Multiexp {
 }
 
 /// Pricing variants.
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub enum Pricing {
@@ -134,7 +134,7 @@ pub struct BuiltinCompat {
 }
 
 /// Spec builtin.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Builtin {
 	/// Builtin name.
 	pub name: String,
@@ -181,7 +181,7 @@ enum PricingCompat {
 }
 
 /// Price for a builtin, with the block number to activate it on
-#[derive(Debug, PartialEq, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PricingAt {
 	/// Description of the activation, e.g. "PunyPony HF, March 12, 2025".

--- a/ethjson/src/spec/clique.rs
+++ b/ethjson/src/spec/clique.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use std::num::NonZeroU64;
 
 /// Clique params deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct CliqueParams {
 	/// period as defined in EIP 225
 	pub period: Option<u64>,
@@ -29,7 +29,7 @@ pub struct CliqueParams {
 }
 
 /// Clique engine deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct Clique {
 	/// CliqueEngine params
 	pub params: CliqueParams,

--- a/ethjson/src/spec/ethash.rs
+++ b/ethjson/src/spec/ethash.rs
@@ -25,7 +25,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 /// Deserializable doppelganger of block rewards for EthashParams
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum BlockReward {
@@ -36,7 +36,7 @@ pub enum BlockReward {
 }
 
 /// Deserializable doppelganger of EthashParams.
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct EthashParams {
@@ -101,7 +101,7 @@ pub struct EthashParams {
 }
 
 /// Ethash engine deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Ethash {
 	/// Ethash params.

--- a/ethjson/src/spec/genesis.rs
+++ b/ethjson/src/spec/genesis.rs
@@ -25,7 +25,7 @@ use crate::{
 use serde::Deserialize;
 
 /// Spec genesis.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct Genesis {

--- a/ethjson/src/spec/hardcoded_sync.rs
+++ b/ethjson/src/spec/hardcoded_sync.rs
@@ -20,7 +20,7 @@ use crate::{bytes::Bytes, hash::H256, uint::Uint};
 use serde::Deserialize;
 
 /// Spec hardcoded sync.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct HardcodedSync {

--- a/ethjson/src/spec/instant_seal.rs
+++ b/ethjson/src/spec/instant_seal.rs
@@ -19,7 +19,7 @@
 use serde::Deserialize;
 
 /// Instant seal engine params deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct InstantSealParams {
@@ -29,7 +29,7 @@ pub struct InstantSealParams {
 }
 
 /// Instant seal engine descriptor.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InstantSeal {
 	/// Instant seal parameters.

--- a/ethjson/src/spec/mod.rs
+++ b/ethjson/src/spec/mod.rs
@@ -29,6 +29,7 @@ pub mod instant_seal;
 pub mod null_engine;
 pub mod params;
 pub mod seal;
+#[allow(clippy::module_inception)]
 pub mod spec;
 pub mod state;
 pub mod step_duration;

--- a/ethjson/src/spec/null_engine.rs
+++ b/ethjson/src/spec/null_engine.rs
@@ -20,7 +20,7 @@ use crate::uint::Uint;
 use serde::Deserialize;
 
 /// Authority params deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct NullEngineParams {
@@ -31,7 +31,7 @@ pub struct NullEngineParams {
 }
 
 /// Null engine descriptor
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NullEngine {
 	/// Ethash params.

--- a/ethjson/src/spec/params.rs
+++ b/ethjson/src/spec/params.rs
@@ -24,7 +24,7 @@ use crate::{
 use serde::Deserialize;
 
 /// Spec params.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct Params {

--- a/ethjson/src/spec/seal.rs
+++ b/ethjson/src/spec/seal.rs
@@ -24,7 +24,7 @@ use crate::{
 use serde::Deserialize;
 
 /// Ethereum seal.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct Ethereum {
@@ -35,7 +35,7 @@ pub struct Ethereum {
 }
 
 /// AuthorityRound seal.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuthorityRoundSeal {
 	/// Seal step.
@@ -45,7 +45,7 @@ pub struct AuthorityRoundSeal {
 }
 
 /// Tendermint seal.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TendermintSeal {
 	/// Seal round.
@@ -57,7 +57,7 @@ pub struct TendermintSeal {
 }
 
 /// Seal variants.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub enum Seal {

--- a/ethjson/src/spec/spec.rs
+++ b/ethjson/src/spec/spec.rs
@@ -65,12 +65,9 @@ pub enum ForkSpec {
 
 impl ForkSpec {
 	/// Returns true if the fork is at or after the merge.
-	pub fn is_eth2(&self) -> bool {
+	pub const fn is_eth2(&self) -> bool {
 		// NOTE: Include new forks in this match arm.
-		matches!(
-			*self,
-			ForkSpec::London | ForkSpec::Merge | ForkSpec::Shanghai
-		)
+		matches!(*self, Self::London | Self::Merge | Self::Shanghai)
 	}
 }
 

--- a/ethjson/src/spec/state.rs
+++ b/ethjson/src/spec/state.rs
@@ -50,7 +50,7 @@ impl State {
 			HashOrMap::Hash(_) => BTreeMap::default(),
 			HashOrMap::Map(map) => map
 				.iter()
-				.filter_map(|(add, ref acc)| acc.builtin.clone().map(|b| (add.clone(), b.into())))
+				.filter_map(|(add, acc)| acc.builtin.clone().map(|b| (*add, b.into())))
 				.collect(),
 		}
 	}
@@ -61,7 +61,7 @@ impl State {
 			HashOrMap::Hash(_) => BTreeMap::default(),
 			HashOrMap::Map(map) => map
 				.iter()
-				.filter_map(|(add, ref acc)| acc.constructor.clone().map(|b| (add.clone(), b)))
+				.filter_map(|(add, acc)| acc.constructor.clone().map(|b| (*add, b)))
 				.collect(),
 		}
 	}

--- a/ethjson/src/spec/step_duration.rs
+++ b/ethjson/src/spec/step_duration.rs
@@ -25,7 +25,7 @@ use crate::uint::Uint;
 /// Step duration can be specified either as a `Uint` (in seconds), in which case it will be
 /// constant, or as a list of pairs consisting of a timestamp of type `Uint` and a duration, in
 /// which case the duration of a step will be determined by a mapping arising from that list.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum StepDuration {

--- a/ethjson/src/spec/validator_set.rs
+++ b/ethjson/src/spec/validator_set.rs
@@ -85,7 +85,7 @@ mod tests {
 				assert!(map.contains_key(&Uint(U256::from(10))));
 				assert!(map.contains_key(&Uint(U256::from(20))));
 			}
-			_ => assert!(false),
+			_ => panic!(),
 		}
 	}
 }

--- a/ethjson/src/state.rs
+++ b/ethjson/src/state.rs
@@ -23,7 +23,7 @@ use crate::{
 use serde::Deserialize;
 
 /// State log deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct Log {
 	/// Address.
 	pub address: Address,

--- a/ethjson/src/test_helpers/blockchain/block.rs
+++ b/ethjson/src/test_helpers/blockchain/block.rs
@@ -21,7 +21,7 @@ use crate::{bytes::Bytes, transaction::Transaction};
 use serde::Deserialize;
 
 /// Blockchain test block deserializer.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct Block {
 	#[serde(rename = "blockHeader")]
 	header: Option<Header>,

--- a/ethjson/src/test_helpers/blockchain/header.rs
+++ b/ethjson/src/test_helpers/blockchain/header.rs
@@ -24,7 +24,7 @@ use crate::{
 use serde::Deserialize;
 
 /// Blockchain test header deserializer.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Header {
 	/// Blocks bloom.

--- a/ethjson/src/test_helpers/blockchain/mod.rs
+++ b/ethjson/src/test_helpers/blockchain/mod.rs
@@ -33,18 +33,13 @@ pub use self::header::Header;
 pub type Test = super::tester::GenericTester<String, BlockChain>;
 
 /// Json Block test possible engine kind.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Deserialize)]
 pub enum Engine {
 	/// Default (old) behaviour.
+	#[default]
 	Ethash,
 	/// No check of block's difficulty and nonce for tests.
 	NoProof,
-}
-
-impl Default for Engine {
-	fn default() -> Self {
-		Engine::Ethash
-	}
 }
 
 /// Blockchain deserialization.
@@ -85,17 +80,17 @@ impl BlockChain {
 	pub fn genesis(&self) -> Genesis {
 		Genesis {
 			seal: Seal::Ethereum(Ethereum {
-				nonce: self.genesis_block.nonce.clone(),
-				mix_hash: self.genesis_block.mix_hash.clone(),
+				nonce: self.genesis_block.nonce,
+				mix_hash: self.genesis_block.mix_hash,
 			}),
 			difficulty: self.genesis_block.difficulty,
-			author: Some(self.genesis_block.author.clone()),
+			author: Some(self.genesis_block.author),
 			timestamp: Some(self.genesis_block.timestamp),
-			parent_hash: Some(self.genesis_block.parent_hash.clone()),
+			parent_hash: Some(self.genesis_block.parent_hash),
 			gas_limit: self.genesis_block.gas_limit,
-			transactions_root: Some(self.genesis_block.transactions_root.clone()),
-			receipts_root: Some(self.genesis_block.receipts_root.clone()),
-			state_root: Some(self.genesis_block.state_root.clone()),
+			transactions_root: Some(self.genesis_block.transactions_root),
+			receipts_root: Some(self.genesis_block.receipts_root),
+			state_root: Some(self.genesis_block.state_root),
 			gas_used: Some(self.genesis_block.gas_used),
 			extra_data: Some(self.genesis_block.extra_data.clone()),
 		}

--- a/ethjson/src/test_helpers/difficulty.rs
+++ b/ethjson/src/test_helpers/difficulty.rs
@@ -18,7 +18,7 @@ use crate::{hash::H256, uint::Uint};
 use serde::Deserialize;
 
 /// Blockchain test header deserializer.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DifficultyTestCase {
 	/// Parent timestamp.

--- a/ethjson/src/test_helpers/skip.rs
+++ b/ethjson/src/test_helpers/skip.rs
@@ -18,7 +18,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 /// Test to skip (only if issue ongoing)
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct SkipTests {
 	/// Block tests
 	pub block: Vec<SkipBlockchainTest>,
@@ -31,7 +31,7 @@ pub struct SkipTests {
 }
 
 /// Block test to skip.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct SkipBlockchainTest {
 	/// Issue reference.
 	pub reference: String,
@@ -42,7 +42,7 @@ pub struct SkipBlockchainTest {
 }
 
 /// State test to skip.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct SkipStateTest {
 	/// Issue reference.
 	pub reference: String,
@@ -53,7 +53,7 @@ pub struct SkipStateTest {
 }
 
 /// State subtest to skip.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct StateSkipSubStates {
 	/// State test number of this item. Or '*' for all state.
 	pub subnumbers: Vec<String>,
@@ -64,7 +64,7 @@ pub struct StateSkipSubStates {
 impl SkipTests {
 	/// Empty skip states.
 	pub fn empty() -> Self {
-		SkipTests {
+		Self {
 			block: Vec::new(),
 			state: Vec::new(),
 			legacy_block: Vec::new(),

--- a/ethjson/src/test_helpers/state.rs
+++ b/ethjson/src/test_helpers/state.rs
@@ -48,7 +48,7 @@ pub struct State {
 }
 
 /// State test transaction deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MultiTransaction {
 	/// Transaction data set.
@@ -80,7 +80,7 @@ pub struct MultiTransaction {
 
 impl MultiTransaction {
 	/// max_priority_fee_per_gas (see EIP-1559)
-	pub fn max_priority_fee_per_gas(&self) -> U256 {
+	pub const fn max_priority_fee_per_gas(&self) -> U256 {
 		if self.max_priority_fee_per_gas.0.is_zero() {
 			self.gas_price.0
 		} else {
@@ -89,7 +89,7 @@ impl MultiTransaction {
 	}
 
 	/// max_fee_per_gas (see EIP-1559)
-	pub fn max_fee_per_gas(&self) -> U256 {
+	pub const fn max_fee_per_gas(&self) -> U256 {
 		if self.max_fee_per_gas.0.is_zero() {
 			self.gas_price.0
 		} else {
@@ -141,7 +141,7 @@ pub type AccessList = Vec<AccessListTuple>;
 
 /// Access list tuple (see https://eips.ethereum.org/EIPS/eip-2930).
 /// Example test spec: https://github.com/ethereum/tests/blob/5490db3ff58d371c0c74826280256ba016b0bd5c/GeneralStateTests/stExample/accessListExample.json
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccessListTuple {
 	/// Address to access
@@ -151,7 +151,7 @@ pub struct AccessListTuple {
 }
 
 /// State test indexes deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct PostStateIndexes {
 	/// Index into transaction data set.
 	pub data: u64,
@@ -162,7 +162,7 @@ pub struct PostStateIndexes {
 }
 
 /// State test indexed state result deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostStateResult {
 	/// Post state hash

--- a/ethjson/src/test_helpers/transaction.rs
+++ b/ethjson/src/test_helpers/transaction.rs
@@ -40,7 +40,7 @@ pub struct TransactionTest {
 }
 
 /// TransactionTest post state.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PostState {
 	/// Transaction sender.

--- a/ethjson/src/test_helpers/trie/input.rs
+++ b/ethjson/src/test_helpers/trie/input.rs
@@ -24,7 +24,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// Trie test input.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Input {
 	/// Input params.
 	pub data: BTreeMap<Bytes, Option<Bytes>>,

--- a/ethjson/src/test_helpers/trie/mod.rs
+++ b/ethjson/src/test_helpers/trie/mod.rs
@@ -27,7 +27,7 @@ use crate::hash::H256;
 use serde::Deserialize;
 
 /// Trie test deserialization.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 pub struct Trie {
 	/// Trie test input.
 	#[serde(rename = "in")]

--- a/ethjson/src/transaction.rs
+++ b/ethjson/src/transaction.rs
@@ -25,7 +25,7 @@ use crate::{
 use serde::Deserialize;
 
 /// Unsigned transaction with signing information deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// Transaction data.

--- a/ethjson/src/uint.rs
+++ b/ethjson/src/uint.rs
@@ -26,21 +26,21 @@ use std::str::FromStr;
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct Uint(pub U256);
 
-impl Into<U256> for Uint {
-	fn into(self) -> U256 {
-		self.0
+impl From<Uint> for U256 {
+	fn from(val: Uint) -> Self {
+		val.0
 	}
 }
 
-impl Into<u64> for Uint {
-	fn into(self) -> u64 {
-		self.0.low_u64()
+impl From<Uint> for u64 {
+	fn from(val: Uint) -> Self {
+		val.0.low_u64()
 	}
 }
 
-impl Into<usize> for Uint {
-	fn into(self) -> usize {
-		self.0.low_u64() as usize
+impl From<Uint> for usize {
+	fn from(val: Uint) -> Self {
+		val.0.low_u64() as Self
 	}
 }
 

--- a/ethjson/src/vm.rs
+++ b/ethjson/src/vm.rs
@@ -54,13 +54,13 @@ pub struct Vm {
 
 impl Vm {
 	/// Returns true if transaction execution run out of gas.
-	pub fn out_of_gas(&self) -> bool {
+	pub const fn out_of_gas(&self) -> bool {
 		self.calls.is_none()
 	}
 }
 
 /// Call deserialization.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Call {
 	/// Call data.
@@ -74,7 +74,7 @@ pub struct Call {
 }
 
 /// Executed transaction.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
 	/// Contract address.
@@ -100,7 +100,7 @@ pub struct Transaction {
 }
 
 /// Environment.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct Env {
 	/// Address.
 	#[serde(rename = "currentCoinbase")]

--- a/jsontests/Cargo.toml
+++ b/jsontests/Cargo.toml
@@ -15,12 +15,12 @@ primitive-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
-clap = "2.32"
+clap = "2.34"
 ethjson = { path = "../ethjson", features = ["test-helpers"] }
 libsecp256k1 = "0.7"
 ethcore-builtin = { path = "../ethcore-builtin" }
 rlp = "0.5"
 sha3 = "0.10"
 parity-bytes = "0.1"
-env_logger = "0.9"
+env_logger = "0.10"
 lazy_static = "1.4.0"

--- a/jsontests/src/state.rs
+++ b/jsontests/src/state.rs
@@ -373,7 +373,7 @@ impl TxType {
 	/// Whether this is a legacy, access list, dynamic fee, etc transaction
 	// Taken from geth's core/types/transaction.go/UnmarshalBinary, but we only detect the transaction
 	// type rather than unmarshal the entire payload.
-	fn from_txbytes(txbytes: &[u8]) -> Self {
+	const fn from_txbytes(txbytes: &[u8]) -> Self {
 		match txbytes[0] {
 			b if b > 0x7f => Self::Legacy,
 			1 => Self::AccessList,

--- a/jsontests/src/state.rs
+++ b/jsontests/src/state.rs
@@ -306,7 +306,6 @@ fn test_run(name: &str, test: Test) {
 
 				match transaction.to {
 					ethjson::maybe::MaybeEmpty::Some(to) => {
-						let data = data;
 						let value = transaction.value.into();
 
 						let _reason = executor.transact_call(

--- a/jsontests/src/state.rs
+++ b/jsontests/src/state.rs
@@ -287,7 +287,7 @@ fn test_run(name: &str, test: Test) {
 				let data: Vec<u8> = transaction.data.into();
 				let metadata =
 					StackSubstateMetadata::new(transaction.gas_limit.into(), &gasometer_config);
-				let executor_state = MemoryStackState::new(metadata, &mut backend);
+				let executor_state = MemoryStackState::new(metadata, &backend);
 				let precompile = JsonPrecompile::precompile(spec).unwrap();
 				let mut executor = StackExecutor::new_with_precompiles(
 					executor_state,

--- a/jsontests/src/vm.rs
+++ b/jsontests/src/vm.rs
@@ -82,7 +82,7 @@ pub fn test(name: &str, test: Test) {
 	let config = Config::frontier();
 	let mut backend = MemoryBackend::new(&vicinity, original_state);
 	let metadata = StackSubstateMetadata::new(test.unwrap_to_gas_limit(), &config);
-	let state = MemoryStackState::new(metadata, &mut backend);
+	let state = MemoryStackState::new(metadata, &backend);
 	let precompile = BTreeMap::new();
 	let mut executor = StackExecutor::new_with_precompiles(state, &config, &precompile);
 

--- a/jsontests/src/vm.rs
+++ b/jsontests/src/vm.rs
@@ -30,16 +30,16 @@ impl Test {
 		});
 
 		MemoryVicinity {
-			gas_price: self.0.transaction.gas_price.clone().into(),
-			origin: self.0.transaction.origin.clone().into(),
+			gas_price: self.0.transaction.gas_price.into(),
+			origin: self.0.transaction.origin.into(),
 			block_hashes: Vec::new(),
-			block_number: self.0.env.number.clone().into(),
-			block_coinbase: self.0.env.author.clone().into(),
-			block_timestamp: self.0.env.timestamp.clone().into(),
-			block_difficulty: self.0.env.difficulty.clone().into(),
-			block_gas_limit: self.0.env.gas_limit.clone().into(),
+			block_number: self.0.env.number.into(),
+			block_coinbase: self.0.env.author.into(),
+			block_timestamp: self.0.env.timestamp.into(),
+			block_difficulty: self.0.env.difficulty.into(),
+			block_gas_limit: self.0.env.gas_limit.into(),
 			chain_id: U256::zero(),
-			block_base_fee_per_gas: self.0.transaction.gas_price.clone().into(),
+			block_base_fee_per_gas: self.0.transaction.gas_price.into(),
 			block_randomness,
 		}
 	}
@@ -54,9 +54,9 @@ impl Test {
 
 	pub fn unwrap_to_context(&self) -> evm::Context {
 		evm::Context {
-			address: self.0.transaction.address.clone().into(),
-			caller: self.0.transaction.sender.clone().into(),
-			apparent_value: self.0.transaction.value.clone().into(),
+			address: self.0.transaction.address.into(),
+			caller: self.0.transaction.sender.into(),
+			apparent_value: self.0.transaction.value.into(),
 		}
 	}
 
@@ -65,11 +65,11 @@ impl Test {
 	}
 
 	pub fn unwrap_to_gas_limit(&self) -> u64 {
-		self.0.transaction.gas.clone().into()
+		self.0.transaction.gas.into()
 	}
 
 	pub fn unwrap_to_post_gas(&self) -> u64 {
-		self.0.gas_left.clone().unwrap().into()
+		self.0.gas_left.unwrap().into()
 	}
 }
 
@@ -102,8 +102,6 @@ pub fn test(name: &str, test: Test) {
 
 		assert!(!reason.is_succeed());
 		assert!(test.0.post_state.is_none() && test.0.gas_left.is_none());
-
-		println!("succeed");
 	} else {
 		let expected_post_gas = test.unwrap_to_post_gas();
 		print!("{:?} ", reason);
@@ -112,8 +110,9 @@ pub fn test(name: &str, test: Test) {
 			runtime.machine().return_value(),
 			test.unwrap_to_return_value()
 		);
-		assert_valid_state(test.0.post_state.as_ref().unwrap(), &backend.state());
+		assert_valid_state(test.0.post_state.as_ref().unwrap(), backend.state());
 		assert_eq!(gas, expected_post_gas);
-		println!("succeed");
 	}
+
+	println!("succeed");
 }


### PR DESCRIPTION
The PR adds the following changes:
-  updates submodules `evm` and  `ethtests` to 12.3
- applies changes proposed by clippy;
- adds CI flow